### PR TITLE
Fixed admin classes declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Next, you have to declare your admin classes:
 white_october_admin:
     ...
     admins:
-        - My\Bundle\Admin\MyClassAdmin
+        - class: My\Bundle\Admin\MyClassAdmin
 ```
 
 


### PR DESCRIPTION
I forgot an attribute in the admin classes declaration !
We should have:

```
admins:
    - class: Blablabla
```

instead of:

```
admins:
    - Blablabla
```

Regards,
William.
