### PR TITLE
Configurable summary fields in the result list

### DIFF
--- a/Action/Action.php
+++ b/Action/Action.php
@@ -28,6 +28,7 @@ abstract class Action extends ContainerAware
     private $routeRequirements;
     private $defaultTemplate;
     private $dependences;
+    private $summaryFields;
     private $fields;
 
     public function __construct(array $options = array())
@@ -235,6 +236,10 @@ abstract class Action extends ContainerAware
         return $this->dependences;
     }
 
+    public function getSummaryFields()
+    {
+        return $this->admin->getSummaryFields();
+    }
 
     public function getFields()
     {

--- a/Action/ActionView.php
+++ b/Action/ActionView.php
@@ -39,6 +39,11 @@ class ActionView
         return $this->action->getFields();
     }
 
+    public function getSummaryFields()
+    {
+        return $this->action->getSummaryFields();
+    }
+
     public function getDataFieldValue($data, $fieldName)
     {
         return $this->admin->getDataFieldValue($data, $fieldName);

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -28,6 +28,7 @@ abstract class Admin extends ContainerAware
 
     private $rawFields;
     private $fields;
+    private $summaryFields;
 
     private $rawFieldGuessers;
     private $fieldGuessers;
@@ -40,6 +41,7 @@ abstract class Admin extends ContainerAware
         $this->rawFields = array();
         $this->rawFieldGuessers = array();
         $this->rawActions = array();
+        $this->summaryFields = array();
 
         $this->preConfigure();
         $this->configure();
@@ -191,6 +193,38 @@ abstract class Admin extends ContainerAware
         }
 
         return $this->fields[$name];
+    }
+
+    public function addSummaryField($name)
+    {
+        if (!in_array($name, $this->summaryFields)) {
+            $this->summaryFields[] = $name;
+        }
+
+        return $this;
+    }
+
+    public function addSummaryFields(array $summaryFields)
+    {
+        foreach ($summaryFields as $name) {
+            $this->addSummaryField($name);
+        }
+
+        return $this;
+    }
+
+    public function getSummaryFields()
+    {
+        if (count($this->summaryFields) === 0) {
+            return $this->getFields();
+        }
+
+        return array_intersect_key($this->getFields(), array_flip($this->summaryFields));
+    }
+
+    public function hasSummaryField($name)
+    {
+        return in_array($name, $this->summaryFields);
     }
 
     public function addFieldGuesser($fieldGuesser)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ protected function configure()
             'isActive',
             // ...
         ))
+        ->addSummaryFields(array(
+            'title',
+        ))
     ;
 }
 ```
@@ -168,3 +171,5 @@ and action is the lowered word before *Action*.
 ### Fields
 
 You should specify fields by using the `addFields()` method.
+
+You can specify which fields to show in the result list by using the `addSummaryFields()` method.

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -30,7 +30,7 @@
             <table>
                 <thead>
                     <tr>
-                        {% for field in _action.fields %}
+                        {% for field in _action.summaryFields %}
                             <th class="{% if loop.first %}first{% endif %}">{{ field.label }}</th>
                         {% endfor %}
                         {% for action in _action.getOption('data_actions') %}
@@ -41,7 +41,7 @@
                 <tbody class="list_content">
                     {% for data in pagerfanta.currentPageResults %}
                         <tr>
-                            {% for field in _action.fields %}
+                            {% for field in _action.summaryFields %}
                                 <td>{{ _action.renderField(field, data) }}</td>
                             {% endfor %}
                             {% for action in _action.getOption('data_actions') %}


### PR DESCRIPTION
I added the capability to specify which fields to show in the result list. This is necessary in cases where your entities have many fields, but you don't want them all to clutter up the result list for that admin page.
