### PR TITLE
fixed a bug in Field\FieldConfigurator::disableAllExcept()

### DIFF
--- a/Field/FieldConfigurator.php
+++ b/Field/FieldConfigurator.php
@@ -68,7 +68,7 @@ class FieldConfigurator
                 throw new \InvalidArgumentException(sprintf('The field "%s" does not exist.', $name));
             }
 
-            $fields = $this->fields[$fieldName];
+            $fields[$fieldName] = $this->fields[$fieldName];
         }
 
         $this->fields = $fields;


### PR DESCRIPTION
disableAllExcept was causing FieldConfigurator::$fields to be set to only one field, instead of an array.
