### PR TITLE
correction in templates names

### DIFF
--- a/Action/ActionView.php
+++ b/Action/ActionView.php
@@ -62,10 +62,10 @@ class ActionView
                 switch ($type) {
                     case 'text':
                     case 'integer':
-                        $template = 'WhiteOctoberAdminBundle:Field:raw.html.twig';
+                        $template = 'WhiteOctoberAdminBundle:fields:raw.html.twig';
                         break;
                     case 'date':
-                        $template = 'WhiteOctoberAdminBundle:Field:date.html.twig';
+                        $template = 'WhiteOctoberAdminBundle:fields:date.html.twig';
                         break;
                 }
             }


### PR DESCRIPTION
I noticed that the template names were wrong in the renderField() method of the ActionView class, just thought I would correct these and let you know... Indeed the directory were these templates reside is named "fields" and not "Field". 

Hope that helps...
