### PR TITLE
Bad closure var names in UpdateAction

### DIFF
--- a/DataManager/Base/Action/UpdateAction.php
+++ b/DataManager/Base/Action/UpdateAction.php
@@ -30,7 +30,7 @@ abstract class UpdateAction extends Action
 
     public function executeController()
     {
-        $findDataByIdClosure = $this->getActionsVars()->get('findDataById');
+        $findDataByIdClosure = $this->getActionsVars()->get('findDataByIdClosure');
         $data = $findDataByIdClosure($this->container->get('request')->attributes->get('id'));
         if (!$data) {
             throw new NotFoundHttpException();
@@ -41,7 +41,7 @@ abstract class UpdateAction extends Action
 
         $form->bindRequest($this->container->get('request'));
         if ($form->isValid()) {
-            $saveDataClosure = $this->getActionsVars()->get('saveData');
+            $saveDataClosure = $this->getActionsVars()->get('saveDataClosure');
             $saveDataClosure($data);
 
             return new RedirectResponse($this->generateUrl('list'));


### PR DESCRIPTION
Hey guys-

This fixes an exception, though I don't pretend to understand the architecture yet :).

I am a little bit confused overall (granted, this is feedback based on very initial work with the bundle) about how different actions extend each other and how these closures work. Specifically, where does this `findDataByIdClosure` come from? Why do I see a method in the `ListAction` only called `getFindDataByIdClosure()`? Are those related? Should I have access to that somehow from `UpdateAction` so I'm calling a method and not a var name?

Thanks guys!
