### PR TITLE
[Field] fixed missing parameter in the constructor.

### DIFF
--- a/Field/Field.php
+++ b/Field/Field.php
@@ -28,14 +28,14 @@ class Field
      *
      * @throws \InvalidArgumentException If the name is empty.
      */
-    public function __construct($name)
+    public function __construct($name, $options = array())
     {
         if (empty($name)) {
             throw new \InvalidArgumentException('The name cannot be empty.');
         }
 
         $this->name = $name;
-        $this->options = array();
+        $this->options = $options;
     }
 
     /**


### PR DESCRIPTION
Currently, in the `initializeFields()` function (Admin class), a field object is created by calling new `Field($name, $options)`.
But the Field class itself doesn't include $options as a second parameter.
So, if we have `$this->addFields(array('isPublished' => array('label' => 'Published')))`,
the label option never get rendered, because the $options variable is always empty
