### PR TITLE
[PropelFieldGuesser] fixed propel field guess column type

### DIFF
--- a/DataManager/Propel/Guesser/PropelFieldGuesser.php
+++ b/DataManager/Propel/Guesser/PropelFieldGuesser.php
@@ -35,6 +35,8 @@ class PropelFieldGuesser implements FieldGuesserInterface
 
         $singularFieldName = preg_replace('#(.+)s$#', '$1', $fieldName);
 
+        $fieldName = ucfirst($fieldName);
+        
         if ($tableMap->hasRelation($fieldName) || $tableMap->hasRelation($singularFieldName)) {
             try {
                 $relationMap = $tableMap->getRelation($fieldName);
@@ -60,8 +62,8 @@ class PropelFieldGuesser implements FieldGuesserInterface
                 ),
                 FieldOptionGuess::HIGH_CONFIDENCE
             );
-        } else if ($tableMap->hasColumn($fieldName)) {
-            switch (strtolower($tableMap->getColumn($fieldName)->getType())) {
+        } else if ($tableMap->hasColumnByPhpName($fieldName)) {
+            switch (strtolower($tableMap->getColumnByPhpName($fieldName)->getType())) {
                 case 'array':
                     break;
                 case 'boolean':


### PR DESCRIPTION
PropelFieldGuesser search a column using hasColumn() function, in propel, this function is used if the parameter is a table column name (for instance: first_name, last_name etc) .
