### PR TITLE
'New' button icon display now doesn't rely on the label.

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -2,10 +2,10 @@
 
 {% block secondarynav %}
     {% if _action.getOption('actions') %}
-        {% for action in _action.getOption('actions') %}
+        {% for key, action in _action.getOption('actions') %}
             <a class="button_slidingdoors button_grey" href="{{ _admin.path(action.route) }}">
                 <span>
-                    {% if action.label|lower == 'new' %}
+                    {% if key|lower == 'new' %}
                         <img class="button_icon" src="{{ asset('bundles/whiteoctoberadmin/images/buttons/icons/add.png') }}" alt="add icon"/>
                     {% endif %}
                     {{ action.label }}


### PR DESCRIPTION
Adjusted 'new' icon display to rely on the array key rather than the label. Means you can customise the label without losing the icon on the button.  Assumes the key is 'new', which for general purposes would be correct (the 'new' action).
