### PR TITLE
Added ability to specify optional options when creating new Fields.

### DIFF
--- a/Field/Field.php
+++ b/Field/Field.php
@@ -25,17 +25,18 @@ class Field
      * Constructor.
      *
      * @param string $name The name.
+     * @param array $options An array of options (default empty)
      *
      * @throws \InvalidArgumentException If the name is empty.
      */
-    public function __construct($name)
+    public function __construct($name, $options = array())
     {
         if (empty($name)) {
             throw new \InvalidArgumentException('The name cannot be empty.');
         }
 
         $this->name = $name;
-        $this->options = array();
+        $this->options = $options;
     }
 
     /**

--- a/Tests/Field/FieldTest.php
+++ b/Tests/Field/FieldTest.php
@@ -46,4 +46,11 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $field->setOption('label', 'mandango');
         $this->assertSame('mandango', $field->getLabel());
     }
+
+    public function testConstructorOptions()
+    {
+        $field = new Field("bar", array("label" => "Bar Label", "otherOption" => "foo"));
+        $this->assertSame("Bar Label", $field->getLabel());
+        $this->assertSame("foo", $field->getOption("otherOption"));
+    }
 }


### PR DESCRIPTION
Pass an optional array of options in when creating new Field objects.  Useful for your Admin's configure() when using addFields().
