### PR TITLE
Added 'formType' option to new/create/edit/update Actions.

### DIFF
--- a/Action/Action.php
+++ b/Action/Action.php
@@ -495,6 +495,24 @@ abstract class Action extends ContainerAware implements ActionInterface
     }
 
     /**
+     * Gets the form used for the action.
+     * This can either be a form type supplied as an option
+     * or a form constructed from the fields supplied
+     * in the action configure() method.
+     *
+     * @return Form A form
+     */
+    protected function getForm()
+    {
+        if (strlen($formType = $this->getOption('formType')))
+        {
+            return $this->container->get('form.factory')->create(new $formType());
+        }
+
+        return $this->createFormFromFields($this->getFields());
+    }
+
+    /**
      * Returns whether a container service exists.
      *
      * @return Boolean Whether a container service exists.

--- a/DataManager/Base/Action/CreateAction.php
+++ b/DataManager/Base/Action/CreateAction.php
@@ -24,6 +24,7 @@ abstract class CreateAction extends Action
                 'template'          => 'WhiteOctoberAdminBundle::default/new.html.twig',
                 'postCreateClosure' => function () {
                 },
+                'formType'          => '',
             ))
             ->setActionDependences(array(
                 'new' => array(),
@@ -36,7 +37,7 @@ abstract class CreateAction extends Action
         $createDataClosure = $this->getActionsVars()->get('createDataClosure');
         $data = $createDataClosure();
 
-        $form = $this->createFormFromFields($this->getFields());
+        $form = $this->getForm();
         $form->setData($data);
 
         $form->bindRequest($this->container->get('request'));

--- a/DataManager/Base/Action/EditAction.php
+++ b/DataManager/Base/Action/EditAction.php
@@ -23,6 +23,7 @@ abstract class EditAction extends Action
             ->setRoute('edit', '/{id}', array(), array('_method' => 'GET'))
             ->addOptions(array(
                 'template' => 'WhiteOctoberAdminBundle::default/edit.html.twig',
+                'formType' => '',
             ))
             ->setActionDependences(array(
                 'list' => array(
@@ -42,7 +43,7 @@ abstract class EditAction extends Action
             throw new NotFoundHttpException();
         }
 
-        $form = $this->createFormFromFields($this->getFields());
+        $form = $this->getForm();
         $form->setData($data);
 
         return $this->render($this->getOption('template'), array('data' => $data, 'form' => $form->createView()));

--- a/DataManager/Base/Action/NewAction.php
+++ b/DataManager/Base/Action/NewAction.php
@@ -22,6 +22,7 @@ abstract class NewAction extends Action
             ->setRoute('new', '/new', array(), array('_method' => 'GET'))
             ->addOptions(array(
                 'template' => 'WhiteOctoberAdminBundle::default/new.html.twig',
+                'formType' => '',
             ))
             ->setActionDependences(array(
                 'list' => array(
@@ -38,7 +39,7 @@ abstract class NewAction extends Action
         $createDataClosure = $this->getActionsVars()->get('createDataClosure');
         $data = $createDataClosure();
 
-        $form = $this->createFormFromFields($this->getFields());
+        $form = $this->getForm();
         $form->setData($data);
 
         return $this->render($this->getOption('template'), array('form' => $form->createView()));

--- a/DataManager/Base/Action/UpdateAction.php
+++ b/DataManager/Base/Action/UpdateAction.php
@@ -23,6 +23,7 @@ abstract class UpdateAction extends Action
             ->setRoute('update', '/{id}', array(), array('_method' => 'PUT'))
             ->addOptions(array(
                 'template' => 'WhiteOctoberAdminBundle::default/edit.html.twig',
+                'formType' => '',
             ))
             ->setActionDependences(array(
                 'edit' => array(),
@@ -38,7 +39,7 @@ abstract class UpdateAction extends Action
             throw new NotFoundHttpException();
         }
 
-        $form = $this->createFormFromFields($this->getFields());
+        $form = $this->getForm();
         $form->setData($data);
 
         $form->bindRequest($this->container->get('request'));


### PR DESCRIPTION
This commit allows you to do something along the lines of the following.

```
protected function configure()
{
    // Form types to use for edit & update
    $this
        ->setActionOption(
            "edit",
            "formType",
            "My\CustomBundle\Form\MyFormType"
        )
        ->setActionOption(
            "update",
            "formType",
            "My\CustomBundle\Form\MyFormType"
        )
    ;
}
```

which will use the specified form class for the relevant actions. Note that this would remove any ability to customise fields in the `configureFieldsByAction` method, but then you would probably use a new form type anyway in that case.
