### PR TITLE
Input submit buttons replaced with yellow/orange buttons

### DIFF
--- a/Resources/public/javascript/jquery.common.js
+++ b/Resources/public/javascript/jquery.common.js
@@ -80,4 +80,52 @@ $(document).ready(function() {
 	})
 */
 
-})
+  // Form submission buttons for main forms
+  $("input.jsreplace[type=submit]").each( function() {
+
+    // Replace these with nice buttons
+
+    // Which class(es) are we using?
+    var useClass = "button_slidingdoors button_yellow";
+    if ($(this).attr("class") != "jsreplace")
+    {
+      // Extra classes - probably size, colour
+      useClass = $(this).attr("class");
+      useClass = useClass.replace(/jsreplace/, "");
+    }
+    var but  = "<a href='#' rel='" + $(this).attr("name") + "' ";
+    but += "class='button_slidingdoors js-form-submit " + useClass + "'";
+    if ($(this).attr("id").length)
+    {
+      but += " id='" + $(this).attr("id") + "'";
+    }
+    but += ">";
+    but += "<span>" + $(this).attr("value") + "</span>";
+    but += "</a>";
+
+    // Anything for onclick?
+    var oc = $(this).attr("onclick");
+
+    $(this).replaceWith(but);
+    but = $("a[rel='" + $(this).attr("name") + "']").last();
+    if (oc)
+    {
+      but.bind("click", oc);
+    }
+  });
+  $("td a.js-form-submit").each( function() {
+
+    // Table cells with replaced buttons in need a width setting for IE
+    var width = $(this).closest("td").width();
+    $(this).closest("td").css("width", width + "px");
+  });
+  $(".js-form-submit").live('click', function() {
+
+    // Add in a hidden input to signify the action
+    // This is based on the rel
+    $(this).closest("form").append("<input type='hidden' name='" + $(this).attr("rel") + "' />");
+
+    $(this).closest("form").submit();
+    return false;
+  });
+});

--- a/Resources/views/default/_form.html.twig
+++ b/Resources/views/default/_form.html.twig
@@ -7,9 +7,7 @@
 <div class="panel_footer">
     <ul>
         <li>
-            <a class="button_slidingdoors button_yellow" onclick="document['adminform'].submit(); return false;">
-                <span>Save</span>
-            </a>
+            <input type="submit" value="Save" class="jsreplace" />
         </li>
     </ul>
 </div>

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -4,7 +4,7 @@
 {% block secondarynav %}
     <ul>
         <li>
-            <a class="button_slidingdoors button_yellow" href="{{ _admin.path('list') }}"><span> &lt; Back to List</span></a>
+            <a class="button_slidingdoors button_grey" href="{{ _admin.path('list') }}"><span> &lt; Back to List</span></a>
         </li>
     </ul>
 {% endblock %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -118,10 +118,13 @@
                                         <form action="{{ url }}" method="POST">
                                             <input type="hidden" name="_method" value="{{ action._method }}" />
                                             <input type="submit" value="{{ action.label }}"
-                                                {% if action.confirm %}
-                                        	    onclick="return confirm('{{ action.confirm }}');"
+                                              {% if action.confirm %}
+                                          	    onclick="return confirm('{{ action.confirm }}');"
                                         	    {% endif %}
-                                            >
+                                              {% if action._method == "DELETE" %}
+                                                class="jsreplace icon delete"
+                                              {% endif %}
+                                              >
                                         </form>
                                     {% endif %}
                                     </li>

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -4,7 +4,7 @@
 {% block secondarynav %}
     <ul>
         <li>
-            <a class="button_slidingdoors button_yellow" href="{{ _admin.path('list') }}"><span> &lt; Back to List</span></a>
+            <a class="button_slidingdoors button_grey" href="{{ _admin.path('list') }}"><span> &lt; Back to List</span></a>
         </li>
     </ul>
 {% endblock %}


### PR DESCRIPTION
This removes the onclick functionality previously which wouldn't gracefully degrade, falls back to normal `<input type="submit" />` buttons and switches them in Javascript for the designed yellow/orange buttons.  This also handles any `onclick="return confirm('foo')"`-style Javascript applied inline on the elements, and applies this to the new designed button.

The links are configured to submit the form they're enclosed by, with the previous name of the button being added back in as a hidden element upon submit, to distinguish between multiple submit buttons on the same page.

Also adjusted the 'back to list' buttons to use the grey style, so they're not considered as actions on the object being edited.
