### PR TITLE
Added action dependency after all actions have been cleaned initially.

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -511,12 +511,17 @@ abstract class Admin extends ContainerAware implements AdminInterface
             }
             $action->setAdmin($this);
             $action->setContainer($this->container);
+
+            $actions[$action->getFullName()] = $action;
+        }
+
+        // Check dependencies
+        foreach ($actions as $action)
+        {
             foreach ($action->getActionDependences() as $actionName => $options) {
                 $dependenceAction = $this->findAction($actions, $actionName);
                 $dependenceAction->mergeOptions($options);
             }
-
-            $actions[$action->getFullName()] = $action;
         }
 
         // action parsers


### PR DESCRIPTION
This was discovered after discovering issue #50.  If I have the following code:

```
public function configure()
{
    // ...
    $this->addActions(array(
        new BatchActionCollection(),
        new ListAction(),
    ));
}
```

then the initialisation of the BatchActionCollection will fail as it can't find the list action required (as the List action hasn't been initialized yet).  This commit moves the dependency check to after the first pass over the raw actions, so that all actions are present in the array, before running the check.
